### PR TITLE
Replace custom google analytics code by internal template

### DIFF
--- a/layouts/partials/tail.html
+++ b/layouts/partials/tail.html
@@ -6,18 +6,6 @@
     }
     //-->
     </script>
-    <script type="text/javascript">
-    <!--
-        var _gaq = _gaq || [];
-        _gaq.push(['_setAccount', {{ .Site.Params.gaCode }}]);
-        _gaq.push(['_trackPageview']);
-
-        (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-        })();
-    -->
-    </script>
+    {{ template "_internal/google_analytics.html" . }}
     </body>
 </html>


### PR DESCRIPTION
The internal template is not inserted when parameter googleAnalytics is not set.